### PR TITLE
Add new staging job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,14 @@ jobs:
         export MYPYPATH=src
         mypy src --check-untyped-defs --disable-error-code=import-untyped
       continue-on-error: true
-  
+
     - name: Run type checking with mypy
       run: mypy src --check-untyped-defs --disable-error-code=import-untyped
       continue-on-error: true
+
+  staging:
+    runs-on:
+      - codebuild-traffic-test-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - run: echo "Running staging/tests job"


### PR DESCRIPTION
- Set up a new CodeBuild-hosted runner using the AWS CodeBuild Console (named traffic-test)
- Added a new job to the GitHub Actions CI workflow that runs on the CodeBuild runner
